### PR TITLE
open display on group join

### DIFF
--- a/ReadyGear/ReadyGear.toc
+++ b/ReadyGear/ReadyGear.toc
@@ -1,7 +1,7 @@
 ## Interface: 110002
 ## Title: |cFFF08080ReadyGear|r - |cffffffffRerölled
 ## Author: daphii
-## Version: 0.1.2
+## Version: 0.1.3
 ## SavedVariables: ReadyGearDB
 ## DefaultState: enabled
 ## Notes: ReadyGear is a simple addon that displays your current gear's enchantments and gems, and your active consumables in a window.

--- a/ReadyGear/display.lua
+++ b/ReadyGear/display.lua
@@ -30,6 +30,15 @@ function Display:Toggle()
     end
 end
 
+function Open()
+    print("Group Joined, Opening Display");
+    local display = ReadyGearDisplay or Display:CreateDisplay();
+    if not display:IsShown() then
+        Display:GenerateAndFillPersonalGearData();
+        display:Show();
+    end
+end
+
 function DEBUG_FRAME_SIZE(frame)
     frame.bg = frame:CreateTexture(nil, "BACKGROUND")
     frame.bg:SetAllPoints(true)
@@ -125,8 +134,13 @@ end
 
 function Display:CreateDisplay()
     ReadyGearDisplay = CreateFrame("Frame", "ReadyGearDisplay", UIParent, "BasicFrameTemplateWithInset");
+    
     _G[ReadyGearDisplay:GetName()] = ReadyGearDisplay;
     tinsert(UISpecialFrames, ReadyGearDisplay:GetName());
+
+    ReadyGearDisplay:RegisterEvent("GROUP_JOINED");
+    ReadyGearDisplay:SetScript("OnEvent", Open);
+
     ReadyGearDisplay:SetSize(frameWidth, frameHeight);
     ReadyGearDisplay:SetPoint("CENTER");
 
@@ -158,4 +172,4 @@ function Display:CreateDisplay()
     return ReadyGearDisplay;
 end
 
-
+ReadyGearDisplay = Display:CreateDisplay();

--- a/ReadyGear/text.lua
+++ b/ReadyGear/text.lua
@@ -72,6 +72,9 @@ Text.CommandsList = {
 }
 
 Text.ChangeLog = "\
+0.1.3\
+- Display will now open when joining a group.\
+\
 0.1.2\
 - Frames now close with escape key.\
 - Added new colour scheme to the personal gear display.\

--- a/change.log
+++ b/change.log
@@ -1,3 +1,6 @@
+0.1.3
+- Display will now open when joining a group.
+
 0.1.2
 *- Added leftover strings to text.lua
 - Frames now close with escape key.


### PR DESCRIPTION
window will now open automatically when joining a group.

using the GROUP_JOINED event. Had to swap window creation to startup instead of on-demand in order to set the event subscription.