### PR TITLE
💬 Update strings for 11.1 socket item

### DIFF
--- a/ReadyGear/text.lua
+++ b/ReadyGear/text.lua
@@ -38,7 +38,7 @@ Text.GemMissingMessage = "Missing Gem!";
 Text.NoGemSlotMessage = "No Gem Slot.";
 Text.GemIssueMessage = "Gem Issue!";
 Text.GemsReadyMessage = "Gems Ready.";
-Text.AddNerGemMessage = "*Add Socket with Nerubian Gemweaver.";
+Text.AddNerGemMessage = "*Add Socket with S.A.D.";
 Text.AddMagGemMessage = "*Add Socket with Magnificent Jeweler's Setting.";
 
 --------------------------------------


### PR DESCRIPTION
Updates the string to use the new socket item [S.A.D.](https://www.wowhead.com/item=232386/s-a-d) instead of the old Season 1 Nerubian Gemweaver